### PR TITLE
OpenTK.Input.Joystick implementation for Mac

### DIFF
--- a/Source/OpenTK/Input/JoystickAxis.cs
+++ b/Source/OpenTK/Input/JoystickAxis.cs
@@ -5,7 +5,7 @@
 // Author:
 //       Stefanos A. <stapostol@gmail.com>
 //
-// Copyright (c) 2006-2013 Stefanos Apostolopoulos
+// Copyright (c) 2006-2014 Stefanos Apostolopoulos
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -58,5 +58,9 @@ namespace OpenTK.Input
         Axis8,
         /// <summary>The tenth axis of the JoystickDevice.</summary>
         Axis9,
+        /// <summary>The eleventh axis of the JoystickDevice.</summary>
+        Axis10,
+        /// <summary>The highest supported axis of the JoystickDevice.</summary>
+        Last = Axis10,
     }
 }

--- a/Source/OpenTK/Input/JoystickButton.cs
+++ b/Source/OpenTK/Input/JoystickButton.cs
@@ -70,5 +70,7 @@ namespace OpenTK.Input
         Button14,
         /// <summary>The sixteenth button of the JoystickDevice.</summary>
         Button15,
+        /// <summary>The last supported button of the JoystickDevice.</summary>
+        Last = Button15,
     }
 }

--- a/Source/OpenTK/Input/JoystickDevice.cs
+++ b/Source/OpenTK/Input/JoystickDevice.cs
@@ -155,7 +155,7 @@ namespace OpenTK.Input
     #region JoystickDevice<TDetail> : JoystickDevice
 
     // Provides platform-specific information about the relevant JoystickDevice.
-    internal sealed class JoystickDevice<TDetail> : JoystickDevice
+    internal class JoystickDevice<TDetail> : JoystickDevice
         where TDetail : new()
     {
         internal JoystickDevice(int id, int axes, int buttons)

--- a/Source/OpenTK/Input/JoystickState.cs
+++ b/Source/OpenTK/Input/JoystickState.cs
@@ -40,8 +40,8 @@ namespace OpenTK.Input
     {
         // If we ever add more values to JoystickAxis or JoystickButton
         // then we'll need to increase these limits.
-        internal const int MaxAxes = 10;
-        internal const int MaxButtons = 32;
+        internal const int MaxAxes = (int)JoystickAxis.Last;
+        internal const int MaxButtons = (int)JoystickButton.Last;
 
         const float ConversionFactor = 1.0f / (short.MaxValue + 0.5f);
 

--- a/Source/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/Source/OpenTK/Platform/MacOS/HIDInput.cs
@@ -210,7 +210,7 @@ namespace OpenTK.Platform.MacOS
             if (recognized)
             {
                 NativeMethods.IOHIDDeviceRegisterInputValueCallback(device, IntPtr.Zero, IntPtr.Zero);
-                NativeMethods.IOHIDDeviceUnscheduleWithRunLoop(device, RunLoop, InputLoopMode);
+                NativeMethods.IOHIDDeviceUnscheduleFromRunLoop(device, RunLoop, InputLoopMode);
             }
         }
 
@@ -849,7 +849,7 @@ namespace OpenTK.Platform.MacOS
                 CFString inCFRunLoopMode);
 
             [DllImport(hid)]
-            public static extern void IOHIDDeviceUnscheduleWithRunLoop(
+            public static extern void IOHIDDeviceUnscheduleFromRunLoop(
                 IOHIDDeviceRef device,
                 CFRunLoop inCFRunLoop,
                 CFString inCFRunLoopMode);

--- a/Source/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/Source/OpenTK/Platform/MacOS/HIDInput.cs
@@ -335,12 +335,30 @@ namespace OpenTK.Platform.MacOS
 
         void AddJoystick(CFAllocatorRef sender, CFAllocatorRef device)
         {
-            throw new NotImplementedException();
+            if (!JoystickDevices.ContainsKey(device))
+            {
+                Debug.Print("Joystick device {0:x} discovered, sender is {1:x}", device, sender);
+                JoystickState state = new JoystickState();
+                state.SetIsConnected(true);
+                JoystickIndexToDevice.Add(KeyboardDevices.Count, device);
+                JoystickDevices.Add(device, state);
+            }
+            else
+            {
+                Debug.Print("Joystick device {0:x} reconnected, sender is {1:x}", device, sender);
+                JoystickState state = JoystickDevices[device];
+                state.SetIsConnected(true);
+                JoystickDevices[device] = state;
+            }
         }
 
         void RemoveJoystick(CFAllocatorRef sender, CFAllocatorRef device)
         {
-            throw new NotImplementedException();
+            Debug.Print("Joystick device {0:x} disconnected, sender is {1:x}", device, sender);
+            // Keep the device in case it comes back later on
+            JoystickState state = JoystickDevices[device];
+            state.SetIsConnected(false);
+            JoystickDevices[device] = state;
         }
 
         #endregion

--- a/Source/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/Source/OpenTK/Platform/MacOS/HIDInput.cs
@@ -376,23 +376,88 @@ namespace OpenTK.Platform.MacOS
             MacJoystick joy = null;
 
             // Retrieve all elements of this device
-            CFArrayRef element_array = NativeMethods.IOHIDDeviceCopyMatchingElements(device, IntPtr.Zero, IntPtr.Zero);
-            if (element_array != IntPtr.Zero)
+            CFArrayRef element_array_ref = NativeMethods.IOHIDDeviceCopyMatchingElements(device, IntPtr.Zero, IntPtr.Zero);
+            if (element_array_ref != IntPtr.Zero)
             {
+                int axes = 0;
+                int buttons = 0;
+                int dpads = 0;
+
                 CFStringRef name_ref = NativeMethods.IOHIDDeviceGetProperty(device, NativeMethods.IOHIDProductKey);
                 string name = CF.CFStringGetCString(name_ref);
                 CF.CFRelease(name_ref);
 
-                joy = new MacJoystick(-1, 0, 0);
+                CFArray element_array = new CFArray(element_array_ref);
+                for (int i = 0; i < element_array.Count; i++)
+                {
+                    IOHIDElementRef element_ref = element_array[i];
+                    IOHIDElementType type = NativeMethods.IOHIDElementGetType(element_ref);
+                    HIDPage page = NativeMethods.IOHIDElementGetUsagePage(element_ref);
+                    int usage = NativeMethods.IOHIDElementGetUsage(element_ref);
+
+                    switch (page)
+                    {
+                        case HIDPage.GenericDesktop:
+                            switch ((HIDUsageGD)usage)
+                            {
+                                case HIDUsageGD.X:
+                                case HIDUsageGD.Y:
+                                case HIDUsageGD.Z:
+                                case HIDUsageGD.Rx:
+                                case HIDUsageGD.Ry:
+                                case HIDUsageGD.Rz:
+                                case HIDUsageGD.Slider:
+                                case HIDUsageGD.Dial:
+                                case HIDUsageGD.Wheel:
+                                    axes++;
+                                    break;
+
+                                case HIDUsageGD.Hatswitch:
+                                    dpads++;
+                                    break;
+                            }
+                            break;
+
+                        case HIDPage.Simulation:
+                            switch ((HIDUsageSim)usage)
+                            {
+                                case HIDUsageSim.Rudder:
+                                case HIDUsageSim.Throttle:
+                                    axes++;
+                                    break;
+                            }
+                            break;
+
+                        case HIDPage.Button:
+                            buttons++;
+                            break;
+                    }
+                }
+
+                joy = new MacJoystick(-1, axes, buttons);
                 joy.Details.Name = name;
                 joy.Details.State.SetIsConnected(true);
-                joy.Details.Capabilities = new JoystickCapabilities(0, 0, true);
+                joy.Details.Capabilities = new JoystickCapabilities(axes, buttons, true);
 
                 //NativeMethods.IOHIDDeviceGetProperty(device, nativem
             }
-            CF.CFRelease(element_array);
+            CF.CFRelease(element_array_ref);
 
             return joy;
+        }
+
+        MacJoystick GetJoystick(int index)
+        {
+            IntPtr device;
+            if (JoystickIndexToDevice.TryGetValue(index, out device))
+            {
+                MacJoystick joystick;
+                if (JoystickDevices.TryGetValue(device, out joystick))
+                {
+                    return joystick;
+                }
+            }
+            return null;
         }
 
         void AddJoystick(CFAllocatorRef sender, CFAllocatorRef device)
@@ -527,16 +592,31 @@ namespace OpenTK.Platform.MacOS
 
         JoystickState IJoystickDriver2.GetState(int index)
         {
+            MacJoystick joystick = GetJoystick(index);
+            if (joystick != null)
+            {
+                return joystick.Details.State;
+            }
             return new JoystickState();
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)
         {
+            MacJoystick joystick = GetJoystick(index);
+            if (joystick != null)
+            {
+                return joystick.Details.Capabilities;
+            }
             return new JoystickCapabilities();
         }
 
         Guid IJoystickDriver2.GetGuid(int index)
         {
+            MacJoystick joystick = GetJoystick(index);
+            if (joystick != null)
+            {
+                //return joystick.Details.Capabilities;
+            }
             return new Guid();
         }
 
@@ -663,6 +743,10 @@ namespace OpenTK.Platform.MacOS
                 IOHIDValueScaleType type) ;
 
             [DllImport(hid)]
+            public static extern IOHIDElementType IOHIDElementGetType(
+                IOHIDElementRef element);
+
+            [DllImport(hid)]
             public static extern int IOHIDElementGetUsage(IOHIDElementRef elem);
 
             [DllImport(hid)]
@@ -670,6 +754,17 @@ namespace OpenTK.Platform.MacOS
 
             public delegate void IOHIDDeviceCallback(IntPtr ctx, IOReturn res, IntPtr sender, IOHIDDeviceRef device);
             public delegate void IOHIDValueCallback(IntPtr ctx, IOReturn res, IntPtr sender, IOHIDValueRef val);
+        }
+
+        enum IOHIDElementType
+        {
+            Input_Misc = 1,
+            Input_Button = 2,
+            Input_Axis = 3,
+            Input_ScanCodes = 4,
+            Output = 129,
+            Feature = 257,
+            Collection = 513
         }
 
         enum IOHIDValueScaleType
@@ -773,6 +868,65 @@ namespace OpenTK.Platform.MacOS
             DPadRight  = 0x92, /* On/Off Control */
             DPadLeft   = 0x93, /* On/Off Control */
             /* 0x94 - 0xFFFF Reserved */
+            Reserved = 0xFFFF
+        }
+
+        enum HIDUsageSim
+        {
+            FlightSimulationDevice    = 0x01, /* Application Collection */
+            AutomobileSimulationDevice    = 0x02, /*             Application Collection */
+            TankSimulationDevice  = 0x03, /*             Application Collection */
+            SpaceshipSimulationDevice = 0x04, /*             Application Collection */
+            SubmarineSimulationDevice = 0x05, /*             Application Collection */
+            SailingSimulationDevice   = 0x06, /*             Application Collection */
+            MotorcycleSimulationDevice    = 0x07, /*             Application Collection */
+            SportsSimulationDevice    = 0x08, /*             Application Collection */
+            AirplaneSimulationDevice  = 0x09, /*             Application Collection */
+            HelicopterSimulationDevice    = 0x0A, /*             Application Collection */
+            MagicCarpetSimulationDevice   = 0x0B, /*             Application Collection */
+            BicycleSimulationDevice   = 0x0C, /*             Application Collection */
+            /* 0x0D - 0x1F Reserved */
+            FlightControlStick    = 0x20, /*             Application Collection */
+            FlightStick   = 0x21, /*             Application Collection */
+            CyclicControl = 0x22, /*             Physical Collection */
+            CyclicTrim    = 0x23, /*             Physical Collection */
+            FlightYoke    = 0x24, /*             Application Collection */
+            TrackControl  = 0x25, /*             Physical Collection */
+            /* 0x26 - 0xAF Reserved */
+            Aileron   = 0xB0, /*             Dynamic Value */
+            AileronTrim   = 0xB1, /*             Dynamic Value */
+            AntiTorqueControl = 0xB2, /*             Dynamic Value */
+            AutopilotEnable   = 0xB3, /*             On/Off Control */
+            ChaffRelease  = 0xB4, /*             One-Shot Control */
+            CollectiveControl = 0xB5, /*             Dynamic Value */
+            DiveBrake = 0xB6, /*             Dynamic Value */
+            ElectronicCountermeasures = 0xB7, /*             On/Off Control */
+            Elevator  = 0xB8, /*             Dynamic Value */
+            ElevatorTrim  = 0xB9, /*             Dynamic Value */
+            Rudder    = 0xBA, /*             Dynamic Value */
+            Throttle  = 0xBB, /*             Dynamic Value */
+            FlightCommunications  = 0xBC, /*             On/Off Control */
+            FlareRelease  = 0xBD, /*             One-Shot Control */
+            LandingGear   = 0xBE, /*             On/Off Control */
+            ToeBrake  = 0xBF, /*             Dynamic Value */
+            Trigger   = 0xC0, /*             Momentary Control */
+            WeaponsArm    = 0xC1, /*             On/Off Control */
+            Weapons   = 0xC2, /*             Selector */
+            WingFlaps = 0xC3, /*             Dynamic Value */
+            Accelerator   = 0xC4, /*             Dynamic Value */
+            Brake = 0xC5, /*             Dynamic Value */
+            Clutch    = 0xC6, /*             Dynamic Value */
+            Shifter   = 0xC7, /*             Dynamic Value */
+            Steering  = 0xC8, /*             Dynamic Value */
+            TurretDirection   = 0xC9, /*             Dynamic Value */
+            BarrelElevation   = 0xCA, /*             Dynamic Value */
+            DivePlane = 0xCB, /*             Dynamic Value */
+            Ballast   = 0xCC, /*             Dynamic Value */
+            BicycleCrank  = 0xCD, /*             Dynamic Value */
+            HandleBars    = 0xCE, /*             Dynamic Value */
+            FrontBrake    = 0xCF, /*             Dynamic Value */
+            RearBrake = 0xD0, /*             Dynamic Value */
+            /* 0xD1 - 0xFFFF Reserved */
             Reserved = 0xFFFF
         }
 

--- a/Source/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/Source/OpenTK/Platform/MacOS/HIDInput.cs
@@ -488,20 +488,119 @@ namespace OpenTK.Platform.MacOS
             //JoystickDevices[device].Details.Capabilities.SetIsConnected(false);
         }
 
-        static MacJoystick UpdateJoystick(MacJoystick state, IOHIDValueRef val)
+        static MacJoystick UpdateJoystick(MacJoystick joy, IOHIDValueRef val)
         {
-            //IOHIDElementRef elem = NativeMethods.IOHIDValueGetElement(val);
-            //int v_int = NativeMethods.IOHIDValueGetIntegerValue(val).ToInt32();
-            //HIDPage page = NativeMethods.IOHIDElementGetUsagePage(elem);
-            //int usage = NativeMethods.IOHIDElementGetUsage(elem);
+            IOHIDElementRef elem = NativeMethods.IOHIDValueGetElement(val);
+            HIDPage page = NativeMethods.IOHIDElementGetUsagePage(elem);
+            int usage = NativeMethods.IOHIDElementGetUsage(elem);
 
-            //switch (page)
-            //{
-            //    case HIDPage.GenericDesktop:
-            //        break;
-            //}
+            switch (page)
+            {
+                case HIDPage.GenericDesktop:
+                    switch ((HIDUsageGD)usage)
+                    {
+                        case HIDUsageGD.X:
+                        case HIDUsageGD.Y:
+                        case HIDUsageGD.Z:
+                        case HIDUsageGD.Rx:
+                        case HIDUsageGD.Ry:
+                        case HIDUsageGD.Rz:
+                        case HIDUsageGD.Slider:
+                        case HIDUsageGD.Dial:
+                        case HIDUsageGD.Wheel:
+                            short offset = GetJoystickAxis(val, elem);
+                            joy.Details.State.SetAxis(TranslateJoystickAxis(usage), offset);
+                            break;
 
-            return state;
+                        case HIDUsageGD.Hatswitch:
+                            break;
+                    }
+                    break;
+
+                case HIDPage.Simulation:
+                    switch ((HIDUsageSim)usage)
+                    {
+                        case HIDUsageSim.Rudder:
+                        case HIDUsageSim.Throttle:
+                            short offset = GetJoystickAxis(val, elem);
+                            joy.Details.State.SetAxis(TranslateJoystickAxis(usage), offset);
+                            break;
+                    }
+                    break;
+
+                case HIDPage.Button:
+                    {
+                        bool pressed = GetJoystickButton(val, elem);
+                        joy.Details.State.SetButton(TranslateJoystickButton(usage), value);
+                    }
+                    break;
+            }
+
+            return joy;
+        }
+
+        static short GetJoystickAxis(IOHIDValueRef val, IOHIDElementRef element)
+        {
+            int max = NativeMethods.IOHIDElementGetLogicalMax(element).ToInt32();
+            int min = NativeMethods.IOHIDElementGetLogicalMin(element).ToInt32();
+            int offset = NativeMethods.IOHIDValueGetIntegerValue(val).ToInt32();
+            if (offset < min)
+                offset = min;
+            if (offset > max)
+                offset = max;
+
+            const int range = short.MaxValue - short.MinValue + 1;
+            const int half_range = short.MaxValue + 1;
+            return (short)((offset - min) * range / (max - min) + half_range);
+        }
+
+        static JoystickAxis TranslateJoystickAxis(int usage)
+        {
+            switch (usage)
+            {
+                case (int)HIDUsageGD.X:
+                    return JoystickAxis.Axis0;
+                case (int)HIDUsageGD.Y:
+                    return JoystickAxis.Axis1;
+
+                case (int)HIDUsageGD.Z:
+                    return JoystickAxis.Axis2;
+                case (int)HIDUsageGD.Rz:
+                    return JoystickAxis.Axis3;
+
+                case (int)HIDUsageGD.Rx:
+                    return JoystickAxis.Axis4;
+                case (int)HIDUsageGD.Ry:
+                    return JoystickAxis.Axis5;
+
+                case (int)HIDUsageGD.Slider:
+                    return JoystickAxis.Axis6;
+                case (int)HIDUsageGD.Dial:
+                    return JoystickAxis.Axis7;
+                case (int)HIDUsageGD.Wheel:
+                    return JoystickAxis.Axis8;
+
+                case (int)HIDUsageSim.Rudder:
+                    return JoystickAxis.Axis9;
+                case (int)HIDUsageSim.Throttle:
+                    return JoystickAxis.Axis10;
+
+                default:
+                    Debug.Print("[Mac] Unknown axis with HID usage {0}", usage);
+                    return 0;
+            }
+        }
+
+        static bool GetJoystickButton(IOHIDValueRef val, IOHIDElementRef element)
+        {
+            // Todo: analogue buttons are transformed to digital
+            int value = NativeMethods.IOHIDValueGetIntegerValue(val).ToInt32();
+            return value >= 1;
+        }
+
+        static JoystickButton TranslateJoystickButton(int usage)
+        {
+
         }
 
         #endregion
@@ -751,6 +850,12 @@ namespace OpenTK.Platform.MacOS
 
             [DllImport(hid)]
             public static extern HIDPage IOHIDElementGetUsagePage(IOHIDElementRef elem);
+
+            [DllImport(hid)]
+            public static extern CFIndex IOHIDElementGetLogicalMax(IOHIDElementRef element);
+
+            [DllImport(hid)]
+            public static extern CFIndex IOHIDElementGetLogicalMin(IOHIDElementRef element);
 
             public delegate void IOHIDDeviceCallback(IntPtr ctx, IOReturn res, IntPtr sender, IOHIDDeviceRef device);
             public delegate void IOHIDValueCallback(IntPtr ctx, IOReturn res, IntPtr sender, IOHIDValueRef val);


### PR DESCRIPTION
This PR tracks the implementation of `OpenTK.Input.Joystick` (IJoystickDriver2) on Mac platforms using IO HID. Do not merge until finished.

Implemented features:
- `Joystick.GetCapabilities()`
- `Joystick.GetState()`
- Hotplugging support (but see below)

Still pending:
- `Joystick.GetGuid()`
- Support for hats or dpads (requires additions to `JoystickCapabilities` and `JoystickState` structures).
- Support for devices outside HIDPage.GenericDesktop + HIDUsageGD.Joystick (e.g. simulation, driving wheels).
- The VM crashes with a stack overflow or similar when a device is unplugged.
