### PR TITLE
Add modifier keys to KeyboardKeyEventArgs

### DIFF
--- a/Source/Examples/OpenTK/Test/GameWindowStates.cs
+++ b/Source/Examples/OpenTK/Test/GameWindowStates.cs
@@ -42,12 +42,15 @@ namespace Examples.Tests
         double variable_refresh_timestep_pos = -1;
         double fixed_update_timestep_pos = -1;
 
+        KeyModifiers modifiers;
+
         public GameWindowStates()
             : base(800, 600, GraphicsMode.Default)
         {
             VSync = VSyncMode.On;
             Keyboard.KeyRepeat = true;
             KeyDown += KeyDownHandler;
+            KeyUp += KeyUpHandler;
             KeyPress += KeyPressHandler;
 
             MouseEnter += delegate { mouse_in_window = true; };
@@ -106,6 +109,12 @@ namespace Examples.Tests
                 case Key.Comma: TargetRenderFrequency--; break;
                 case Key.Period: TargetRenderFrequency++; break;
             }
+            modifiers = e.Modifiers;
+        }
+
+        void KeyUpHandler(object sender, KeyboardKeyEventArgs e)
+        {
+            modifiers = e.Modifiers;
         }
 
         void MouseMoveHandler(object sender, MouseMoveEventArgs e)
@@ -136,10 +145,10 @@ namespace Examples.Tests
             return offset + gfx.MeasureString(str, TextFont).Width;
         }
 
-        static int DrawKeyboards(Graphics gfx, int line)
+        int DrawKeyboards(Graphics gfx, int line)
         {
             line++;
-            DrawString(gfx, "Keyboard:", line++);
+            DrawString(gfx, String.Format("Keyboard ({0}):", modifiers), line++);
             for (int i = 0; i < 4; i++)
             {
                 var state = OpenTK.Input.Keyboard.GetState(i);

--- a/Source/OpenTK/Input/KeyModifiers.cs
+++ b/Source/OpenTK/Input/KeyModifiers.cs
@@ -1,0 +1,57 @@
+#region License
+//
+// HatPosition.cs
+//
+// Author:
+//       Stefanos A. <stapostol@gmail.com>
+//
+// Copyright (c) 2006-2014 Stefanos Apostolopoulos
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenTK.Input
+{
+    /// <summary>
+    /// Enumerates modifier keys.
+    /// </summary>
+    [Flags]
+    public enum KeyModifiers : byte
+    {
+        /// <summary>
+        /// The alt key modifier (option on Mac).
+        /// </summary>
+        Alt = 1 << 0,
+
+        /// <summary>
+        /// The control key modifier.
+        /// </summary>
+        Control = 1 << 1,
+
+        /// <summary>
+        /// The shift key modifier.
+        /// </summary>
+        Shift = 1 << 2
+    }
+}

--- a/Source/OpenTK/Input/KeyboardDevice.cs
+++ b/Source/OpenTK/Input/KeyboardDevice.cs
@@ -222,6 +222,28 @@ namespace OpenTK.Input
             }
         }
 
+        internal KeyModifiers GetModifiers()
+        {
+            KeyModifiers mods = 0;
+
+            if (this[Key.AltLeft] || this[Key.AltRight])
+            {
+                mods |= KeyModifiers.Alt;
+            }
+
+            if (this[Key.ControlLeft] || this[Key.ControlRight])
+            {
+                mods |= KeyModifiers.Control;
+            }
+
+            if (this[Key.ShiftLeft] || this[Key.ShiftRight])
+            {
+                mods |= KeyModifiers.Shift;
+            }
+
+            return mods;
+        }
+
         #endregion
     }
 }

--- a/Source/OpenTK/Input/KeyboardKeyEventArgs.cs
+++ b/Source/OpenTK/Input/KeyboardKeyEventArgs.cs
@@ -46,6 +46,7 @@ namespace OpenTK.Input
         #region Fields
 
         Key key;
+        KeyModifiers mods;
         uint scancode;
 
         #endregion
@@ -83,12 +84,50 @@ namespace OpenTK.Input
         /// <summary>
         /// Gets the scancode which generated this event.
         /// </summary>
+        [CLSCompliant(false)]
         public uint ScanCode
         {
             get { return scancode; }
             internal set { scancode = value; }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether <see cref="OpenTK.Input.KeyModifiers.Alt"/> is pressed.
+        /// </summary>
+        /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
+        public bool Alt
+        {
+            get { return (mods & KeyModifiers.Alt) != 0; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="OpenTK.Input.KeyModifiers.Control"/> is pressed.
+        /// </summary>
+        /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
+        public bool Control
+        {
+            get { return (mods & KeyModifiers.Control) != 0; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="OpenTK.Input.KeyModifiers.Shift"/> is pressed.
+        /// </summary>
+        /// <value><c>true</c> if pressed; otherwise, <c>false</c>.</value>
+        public bool Shift
+        {
+            get { return (mods & KeyModifiers.Shift) != 0; }
+        }
+
+        /// <summary>
+        /// Gets a bitwise combination representing the <see cref="OpenTK.Input.KeyModifiers"/>
+        /// that are currently pressed.
+        /// </summary>
+        /// <value>The modifiers.</value>
+        public KeyModifiers Modifiers
+        {
+            get { return mods; }
+            internal set { mods = value; }
+        }
 
         #endregion
     }

--- a/Source/OpenTK/OpenTK.csproj
+++ b/Source/OpenTK/OpenTK.csproj
@@ -801,6 +801,7 @@
     <Compile Include="Input\JoystickHat.cs" />
     <Compile Include="Input\HatPosition.cs" />
     <Compile Include="Input\JoystickHatState.cs" />
+    <Compile Include="Input\KeyModifiers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Source/OpenTK/Platform/MacOS/CarbonGLNative.cs
+++ b/Source/OpenTK/Platform/MacOS/CarbonGLNative.cs
@@ -34,6 +34,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Text;
 using OpenTK.Graphics;
+using OpenTK.Input;
 
 namespace OpenTK.Platform.MacOS
 {
@@ -362,7 +363,7 @@ namespace OpenTK.Platform.MacOS
                     break;
             }
 
-            OpenTK.Input.Key key;
+            Key key;
             switch (evt.KeyboardEventKind)
             {
                 case KeyboardEventKind.RawKeyRepeat:
@@ -371,29 +372,11 @@ namespace OpenTK.Platform.MacOS
                     break;
 
                 case KeyboardEventKind.RawKeyDown:
-                    Keymap.TryGetValue(code, out key);
-                    // Legacy keyboard API
-                    InputDriver.Keyboard[0].SetKey(key, (uint)code, true);
-
-                    // Raise KeyDown for new keyboard API
-                    mKeyDownArgs.Key = key;
-                    KeyDown(this, mKeyDownArgs);
-
-                    // Raise KeyPress for new keyboard API
-                    if (!Char.IsControl(mKeyPressArgs.KeyChar))
-                    {
-                        OnKeyPress(mKeyPressArgs);
-                    }
+                    ProcessKeyDown(code);
                     return OSStatus.NoError;
 
                 case KeyboardEventKind.RawKeyUp:
-                    Keymap.TryGetValue(code, out key);
-                    // Legacy keyboard API
-                    InputDriver.Keyboard[0].SetKey(key, (uint)code, false);
-
-                    // Raise KeyUp for new keyboard API
-                    mKeyUpArgs.Key = key;
-                    KeyUp(this, mKeyUpArgs);
+                    ProcessKeyUp(code);
                     return OSStatus.NoError;
 
                 case KeyboardEventKind.RawKeyModifiersChanged:
@@ -611,6 +594,56 @@ namespace OpenTK.Platform.MacOS
             charCode = API.GetEventKeyboardChar(inEvent);
         }
 
+        void ProcessKeyDown(MacOSKeyCode code)
+        {
+            Key key;
+            Keymap.TryGetValue(code, out key);
+
+            // Legacy keyboard API
+            KeyboardDevice keyboard = InputDriver.Keyboard[0];
+            keyboard.SetKey(key, (uint)code, true);
+
+            // Raise KeyDown for new keyboard API
+            mKeyDownArgs.Key = key;
+            mKeyDownArgs.Modifiers = keyboard.GetModifiers();
+
+            KeyDown(this, mKeyDownArgs);
+
+            // Raise KeyPress for new keyboard API
+            if (!Char.IsControl(mKeyPressArgs.KeyChar))
+            {
+                OnKeyPress(mKeyPressArgs);
+            }
+        }
+
+        void ProcessKeyUp(MacOSKeyCode code)
+        {
+            Key key;
+            Keymap.TryGetValue(code, out key);
+
+            // Legacy keyboard API
+            KeyboardDevice keyboard = InputDriver.Keyboard[0];
+            keyboard.SetKey(key, (uint)code, false);
+
+            // Raise KeyUp for new keyboard API
+            mKeyUpArgs.Key = key;
+            mKeyDownArgs.Modifiers = keyboard.GetModifiers();
+
+            KeyUp(this, mKeyUpArgs);
+        }
+
+        void ProcessKey(MacOSKeyCode code, bool pressed)
+        {
+            if (pressed)
+            {
+                ProcessKeyDown(code);
+            }
+            else
+            {
+                ProcessKeyUp(code);
+            }
+        }
+
         private void ProcessModifierKey(IntPtr inEvent)
         {
             MacOSKeyModifiers modifiers = API.GetEventKeyModifiers(inEvent);
@@ -621,25 +654,32 @@ namespace OpenTK.Platform.MacOS
             bool option = (modifiers & MacOSKeyModifiers.Option) != 0 ? true : false;
             bool shift = (modifiers & MacOSKeyModifiers.Shift) != 0 ? true : false;
             
-            Debug.Print("Modifiers Changed: {0}", modifiers);
-            
             Input.KeyboardDevice keyboard = InputDriver.Keyboard[0];
 
             if (keyboard[OpenTK.Input.Key.AltLeft] ^ option)
-                keyboard.SetKey(OpenTK.Input.Key.AltLeft, (uint)MacOSKeyCode.OptionAlt, option);
+            {
+                ProcessKey(MacOSKeyCode.OptionAlt, option);
+            }
             
             if (keyboard[OpenTK.Input.Key.ShiftLeft] ^ shift)
-                keyboard.SetKey(OpenTK.Input.Key.ShiftLeft, (uint)MacOSKeyCode.Shift, shift);
-            
+            {
+                ProcessKey(MacOSKeyCode.Shift, shift);
+            }
+
             if (keyboard[OpenTK.Input.Key.WinLeft] ^ command)
-                keyboard.SetKey(OpenTK.Input.Key.WinLeft, (uint)MacOSKeyCode.Command, command);
-            
+            {
+                ProcessKey(MacOSKeyCode.Command, command);
+            }
+
             if (keyboard[OpenTK.Input.Key.ControlLeft] ^ control)
-                keyboard.SetKey(OpenTK.Input.Key.ControlLeft, (uint)MacOSKeyCode.Control, control);
+            {
+                ProcessKey(MacOSKeyCode.Control, control);
+            }
             
             if (keyboard[OpenTK.Input.Key.CapsLock] ^ caps)
-                keyboard.SetKey(OpenTK.Input.Key.CapsLock, (uint)MacOSKeyCode.CapsLock, caps);
-            
+            {
+                ProcessKey(MacOSKeyCode.CapsLock, caps);
+            }
         }
 
         Rect GetClientSize()

--- a/Source/OpenTK/Platform/MacOS/MacOSKeyMap.cs
+++ b/Source/OpenTK/Platform/MacOS/MacOSKeyMap.cs
@@ -43,7 +43,7 @@ namespace OpenTK.Platform.MacOS
             // comments indicate members of the Key enum that are missing
             
             Add(MacOSKeyCode.A, Key.A);
-            // AltLeft
+            Add(MacOSKeyCode.OptionAlt, Key.AltLeft);
             // AltRight
             Add(MacOSKeyCode.B, Key.B);
             
@@ -55,7 +55,7 @@ namespace OpenTK.Platform.MacOS
             // Capslock
             // Clear
             Add(MacOSKeyCode.Comma, Key.Comma);
-            // ControlLeft 
+            Add(MacOSKeyCode.Control, Key.ControlLeft);
             // ControlRight
             Add(MacOSKeyCode.D, Key.D);
             Add(MacOSKeyCode.Del, Key.Delete);
@@ -139,7 +139,7 @@ namespace OpenTK.Platform.MacOS
             Add(MacOSKeyCode.S, Key.S);
             // ScrollLock
             Add(MacOSKeyCode.Semicolon, Key.Semicolon);
-            //Key.ShiftLeft 
+            Add(MacOSKeyCode.Shift, Key.ShiftLeft);
             //Key.ShiftRight 
             Add(MacOSKeyCode.Slash, Key.Slash);
             // Key.Sleep
@@ -151,7 +151,7 @@ namespace OpenTK.Platform.MacOS
             Add(MacOSKeyCode.Up, Key.Up);
             Add(MacOSKeyCode.V, Key.V);
             Add(MacOSKeyCode.W, Key.W);
-            // WinKeyLeft
+            Add(MacOSKeyCode.Command, Key.WinLeft);
             // WinKeyRight
             Add(MacOSKeyCode.X, Key.X);
             Add(MacOSKeyCode.Y, Key.Y);

--- a/Source/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2.cs
@@ -350,10 +350,46 @@ namespace OpenTK.Platform.SDL2
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_NumJoysticks", ExactSpelling = true)]
         public static extern int NumJoysticks();
 
+        public static int PeepEvents(ref Event e, EventAction action, EventType min, EventType max)
+        {
+            unsafe
+            {
+                fixed (Event* pe = &e)
+                {
+                    return PeepEvents(pe, 1, action, min, max);
+                }
+            }
+        }
+
+        public static int PeepEvents(Event[] e, int count, EventAction action, EventType min, EventType max)
+        {
+            if (e == null)
+                throw new ArgumentNullException();
+            if (count <= 0 || count > e.Length)
+                throw new ArgumentOutOfRangeException();
+
+            unsafe
+            {
+                fixed (Event *pe = e)
+                {
+                    return PeepEvents(pe, count, action, min, max);
+                }
+            }
+        }
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_PeepEvents", ExactSpelling = true)]
+        unsafe static extern int PeepEvents(Event* e, int count, EventAction action, EventType min, EventType max);
+
+
         [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_PixelFormatEnumToMasks", ExactSpelling = true)]
         public static extern bool PixelFormatEnumToMasks(uint format, out int bpp, 
             out uint rmask, out uint gmask, out uint bmask, out uint amask);
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_PollEvent", ExactSpelling = true)]
+        public static extern int PollEvent(out Event e);
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_PumpEvents", ExactSpelling = true)]
@@ -587,6 +623,13 @@ namespace OpenTK.Platform.SDL2
         CORE = 0x0001,
         COMPATIBILITY = 0x0002,
         ES = 0x0004
+    }
+
+    enum EventAction
+    {
+        Add,
+        Peek,
+        Get
     }
 
     enum EventState

--- a/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2KeyMap.cs
@@ -62,8 +62,8 @@ namespace OpenTK.Platform.SDL2
             Add(Code.CAPSLOCK, Key.CapsLock);
             Add(Code.LCTRL, Key.ControlLeft);
             Add(Code.LSHIFT, Key.ShiftLeft);
-            Add(Code.LALT, Key.WinLeft);
-            Add(Code.MENU, Key.AltLeft);
+            Add(Code.LALT, Key.AltLeft);
+            Add(Code.MENU, Key.WinLeft);
             Add(Code.SPACE, Key.Space);
             Add(Code.RALT, Key.AltRight);
             //Add(Code., Key.WinRight);

--- a/Source/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/Source/OpenTK/Platform/Windows/WinGLNative.cs
@@ -511,11 +511,13 @@ namespace OpenTK.Platform.Windows
                 if (pressed)
                 {
                     key_down.Key = key;
+                    key_down.Modifiers = keyboard.GetModifiers();
                     KeyDown(this, key_down);
                 }
                 else
                 {
                     key_up.Key = key;
+                    key_up.Modifiers = keyboard.GetModifiers();
                     KeyUp(this, key_up);
                 }
             }

--- a/Source/OpenTK/Platform/X11/X11GLNative.cs
+++ b/Source/OpenTK/Platform/X11/X11GLNative.cs
@@ -849,11 +849,15 @@ namespace OpenTK.Platform.X11
                         Key key;
                         if (driver.TranslateKey(ref e.KeyEvent, out key))
                         {
+                            // Update legacy GameWindow.Keyboard API:
+                            keyboard.SetKey(key, (uint)e.KeyEvent.keycode, pressed);
+
                             if (pressed)
                             {
                                 // Raise KeyDown event
                                 KeyDownEventArgs.Key = key;
                                 KeyDownEventArgs.ScanCode = (uint)e.KeyEvent.keycode;
+                                KeyDownEventArgs.Modifiers = keyboard.GetModifiers();
                                 KeyDown(this, KeyDownEventArgs);
                             }
                             else
@@ -861,11 +865,9 @@ namespace OpenTK.Platform.X11
                                 // Raise KeyUp event
                                 KeyUpEventArgs.Key = key;
                                 KeyUpEventArgs.ScanCode = (uint)e.KeyEvent.keycode;
+                                KeyUpEventArgs.Modifiers = keyboard.GetModifiers();
                                 KeyUp(this, KeyDownEventArgs);
                             }
-
-                            // Update legacy GameWindow.Keyboard API:
-                            keyboard.SetKey(key, (uint)e.KeyEvent.keycode, pressed);
 
                             if (pressed)
                             {


### PR DESCRIPTION
This makes keyboard handling more straightforward:

``` csharp
var gw = new GameWindow();
gw.KeyDown += (sender, e) =>
{
    if (e.Key == Key.Enter && e.Alt)
        gw.WindowState = WindowState.Fullscreen;
};
```
